### PR TITLE
chore: bump magnum-cluster-api to 0.38.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN --mount=type=bind,from=magnum,source=/,target=/src/magnum,readwrite <<EOF ba
 uv pip install \
     --constraint /upper-constraints.txt \
         /src/magnum \
-        magnum-cluster-api==0.37.0
+        magnum-cluster-api==0.38.0
 EOF
 
 FROM ghcr.io/vexxhost/python-base:main@sha256:cd5f90fbe48ea093f842d4a685b9edfa5c80f4768b066f9b9957bbf47155c245


### PR DESCRIPTION
## Summary

- Bump the Magnum image build from `magnum-cluster-api==0.37.0` to `0.38.0`.
- Track the `magnum-cluster-api` 0.38.0 release PR before this image update merges.

Depends-On: https://github.com/vexxhost/magnum-cluster-api/pull/1090

## Validation

- `git diff --check HEAD^ HEAD`
- Confirmed https://github.com/vexxhost/magnum-cluster-api/pull/1090 is open and mergeable; GitHub checks are green and `oss/check` is still in progress.
- CI image build ran on this PR and failed at dependency resolution because `magnum-cluster-api==0.38.0` is not published yet. This is the expected blocker until the dependent release PR lands/publishes.

Not run locally:

- `docker buildx build --check --build-context magnum=https://opendev.org/openstack/magnum.git .` because the local Docker daemon is not running.
- Full local image build for the same reason, and because `magnum-cluster-api==0.38.0` is expected to become installable only after the dependent release PR lands/publishes.