### PR TITLE
Install Magnum from the OpenStack package index

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,13 +25,7 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: vexxhost/docker-atmosphere/.github/actions/checkout@e72a4bb3670421e6ec38413e3e90b11259d86ea1 # main
-        with:
-          repository: openstack/magnum
-          ref: 5a492d64c1146744b3d6237b47d507422480840f # master
-
       - uses: vexxhost/docker-atmosphere/.github/actions/build-image@e72a4bb3670421e6ec38413e3e90b11259d86ea1 # main
         with:
           image-name: magnum
-          build-contexts: magnum=openstack/magnum
           push: ${{ github.event_name != 'pull_request' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,12 @@ RUN tar -xzf /helm.tar.gz
 RUN mv /${TARGETOS}-${TARGETARCH}/helm /usr/bin/helm
 
 FROM ghcr.io/vexxhost/openstack-venv-builder:main@sha256:dd3adf3788a31aad0997c9ed789457b74bb4b7f1d83723aafae9af458cd942ce AS build
-RUN --mount=type=bind,from=magnum,source=/,target=/src/magnum,readwrite <<EOF bash -xe
+ENV UV_INDEX=https://packages.vexxhost.com/pypi/openstack/simple/
+ARG MAGNUM_VERSION=22.0.0+a8e.9.0
+RUN <<EOF bash -xe
 uv pip install \
     --constraint /upper-constraints.txt \
-        /src/magnum \
+        "magnum==${MAGNUM_VERSION}" \
         magnum-cluster-api==0.38.0
 EOF
 


### PR DESCRIPTION
## Summary
- install Magnum 22.0.0+a8e.9.0 from the public OpenStack Python package index
- remove the OpenStack Magnum source checkout and BuildKit context
- retain the existing magnum-cluster-api pin

## Validation
- confirmed the pinned Magnum wheel and source distribution are published
- validated the branch diff and DCO signoff