### PR TITLE
chore(deps): update Magnum to 21.0.1+a8e.7.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN mv /${TARGETOS}-${TARGETARCH}/helm /usr/bin/helm
 
 FROM ghcr.io/vexxhost/openstack-venv-builder:2025.2@sha256:5528f59558327af1bfd74b440ddeeb112f5163ba234007e27fab82037da41192 AS build
 ENV UV_INDEX=https://packages.vexxhost.com/pypi/openstack/simple/
-ARG MAGNUM_VERSION=21.0.1+a8e.7.0
+ARG MAGNUM_VERSION=21.0.1+a8e.7.2
 RUN <<EOF bash -xe
 uv pip install \
     --constraint /upper-constraints.txt \


### PR DESCRIPTION
Bumps Magnum to the Atmosphere release containing the trust/application-credential backports.

This completes the stable/2025.2 image chain together with magnum-cluster-api 0.38.1, which opts the CAPI driver out of trust creation.

Validation:
- release wheel is published in the VEXXHOST OpenStack package index
- SHA-256: 1d821f736ea5f5608d4ff1f33cfef270ca2aa3d8e4435e015b6e01d9147cae5c
- wheel contains the driver needs_trust hook and application-credential trust handling
- git diff --check