### PR TITLE
chore(deps): update Magnum to 20.0.2+a8e.0.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN mv /${TARGETOS}-${TARGETARCH}/helm /usr/bin/helm
 
 FROM ghcr.io/vexxhost/openstack-venv-builder:2025.1@sha256:c8fce46ccda5251f5c59006603cc0594599b2d73b65eabbc8d73bec103846541 AS build
 ENV UV_INDEX=https://packages.vexxhost.com/pypi/openstack/simple/
-ARG MAGNUM_VERSION=20.0.2+a8e.0.0
+ARG MAGNUM_VERSION=20.0.2+a8e.0.2
 RUN <<EOF bash -xe
 uv pip install \
     --constraint /upper-constraints.txt \


### PR DESCRIPTION
Bumps Magnum to the Atmosphere release containing the trust/application-credential backports.

This completes the stable/2025.1 image chain together with magnum-cluster-api 0.38.1, which opts the CAPI driver out of trust creation.

Validation:
- release wheel is published in the VEXXHOST OpenStack package index
- SHA-256: 864bd355298a9689de32db79bc246a8d25ffe6cfd3d5aa5a20d2053b736a9033
- wheel contains the driver needs_trust hook and application-credential trust handling
- git diff --check